### PR TITLE
Update manifest and appdata

### DIFF
--- a/build-aux/flatpak/io.github.lainsce.Emulsion.json
+++ b/build-aux/flatpak/io.github.lainsce.Emulsion.json
@@ -6,13 +6,10 @@
     "command" : "io.github.lainsce.Emulsion",
     "rename-icon" : "io.github.lainsce.EmulsionDevel",
     "finish-args" : [
-        "--filesystem=xdg-pictures",
-        "--filesystem=xdg-download",
         "--filesystem=xdg-run/gvfsd",
         "--socket=wayland",
         "--socket=fallback-x11",
         "--socket=session-bus",
-        "--share=network",
         "--share=ipc",
         "--device=dri"
     ],

--- a/data/io.github.lainsce.Emulsion.appdata.xml.in
+++ b/data/io.github.lainsce.Emulsion.appdata.xml.in
@@ -19,6 +19,7 @@
     <url type="homepage">https://github.com/lainsce/emulsion/</url>
     <url type="bugtracker">https://github.com/lainsce/emulsion/issues</url>
     <url type="donation">https://www.patreon.com/lainsce/</url>
+    <url type="translate">https://github.com/lainsce/emulsion/blob/master/po/README.md</url>
     <screenshots>
         <screenshot type="default">
             <image>https://raw.githubusercontent.com/lainsce/emulsion/master/data/shot.png</image>
@@ -36,6 +37,7 @@
     <custom>
       <value key="GnomeSoftware::key-colors">[(51, 209, 122)]</value>
     </custom>
+    <translation type="gettext">io.github.lainsce.Emulsion</translation>
     <releases>
         <release version="2.0.1" date="2021-08-18">
             <description>


### PR DESCRIPTION
Emulsion is missing some `finish-args` in FlatHub repository, I have removed three that do not affect its functionality.